### PR TITLE
Remove use of Geocoding API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "laravel/tinker": "^2.5",
         "maatwebsite/excel": "^3.1",
         "mstaack/laravel-postgis": "^5.4",
-        "spatie/geocoder": "^3.12",
         "spatie/laravel-query-builder": "^4.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec067c022b3a2180aa509a32e2495093",
+    "content-hash": "7f2fcafd4150ec57587d0cfa0febbc7b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3993,76 +3993,6 @@
                 }
             ],
             "time": "2021-09-25T23:10:38+00:00"
-        },
-        {
-            "name": "spatie/geocoder",
-            "version": "3.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/geocoder.git",
-                "reference": "b251c593924ea5d1a38dc55bd549e95ee35678e1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/geocoder/zipball/b251c593924ea5d1a38dc55bd549e95ee35678e1",
-                "reference": "b251c593924ea5d1a38dc55bd549e95ee35678e1",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/guzzle": "^6.5|^7.0",
-                "illuminate/support": "^6.0|^7.0|^8.67|^9.0",
-                "php": "^7.2|^8.0"
-            },
-            "require-dev": {
-                "orchestra/testbench": "^4.0|^5.0|^6.0",
-                "phpunit/phpunit": "^8.5.21|^9.0|^9.4.4"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Spatie\\Geocoder\\GeocoderServiceProvider"
-                    ],
-                    "aliases": {
-                        "Geocoder": "Spatie\\Geocoder\\Facades\\Geocoder"
-                    }
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\Geocoder\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be"
-                }
-            ],
-            "description": "Geocoding addresses to coordinates",
-            "homepage": "https://github.com/spatie/geocoder",
-            "keywords": [
-                "coordinate",
-                "geocode",
-                "laravel",
-                "location",
-                "map"
-            ],
-            "support": {
-                "issues": "https://github.com/spatie/geocoder/issues",
-                "source": "https://github.com/spatie/geocoder/tree/3.12.0"
-            },
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                }
-            ],
-            "time": "2022-02-09T07:50:05+00:00"
         },
         {
             "name": "spatie/laravel-query-builder",


### PR DESCRIPTION
Remove the use of Geocoding API since the same information can be obtained from the Places API without the risk of inconsistency.